### PR TITLE
fix: change a class attribute to className!

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -15,7 +15,7 @@ const badgeVariant = cva('w-5 h-5 rounded-full', {
 
 export default function Badge({ variant }) {
   return (
-    <div class="inline-flex gap-2 items-center justify-center md:pl-1 md:pr-4 h-8 text-sm rounded-full md:border-2 border-hlight text-center text-primary-700 md:cursor-pointer md:transition md:duration-200 md:hover:scale-105 md:hover:shadow-md">
+    <div className="inline-flex gap-2 items-center justify-center md:pl-1 md:pr-4 h-8 text-sm rounded-full md:border-2 border-hlight text-center text-primary-700 md:cursor-pointer md:transition md:duration-200 md:hover:scale-105 md:hover:shadow-md">
       <span className={badgeVariant({ variant })}></span>
       <span className="hidden md:block">{variant || 'open'}</span>
     </div>


### PR DESCRIPTION
Changed a `class` that we let slip into the codebase by a `className`.

Thank you to merge.
