### PR TITLE
refactor: add prettier-tailwind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
       "devDependencies": {
         "eslint-config-prettier": "^8.8.0",
         "husky": "^8.0.3",
-        "prettier": "^2.8.7"
+        "prettier": "^2.8.7",
+        "prettier-plugin-tailwindcss": "^0.2.7"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3312,6 +3313,80 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.7.tgz",
+      "integrity": "sha512-jQopIOgjLpX+y8HeD56XZw7onupRTC0cw7eKKUimI7vhjkPF5/1ltW5LyqaPtSyc8HvEpvNZsvvsGFa2qpa59w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-php": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@shufo/prettier-plugin-blade": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "prettier": ">=2.2.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*",
+        "prettier-plugin-twig-melody": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-php": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@shufo/prettier-plugin-blade": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "prettier-plugin-twig-melody": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "eslint-config-prettier": "^8.8.0",
     "husky": "^8.0.3",
-    "prettier": "^2.8.7"
+    "prettier": "^2.8.7",
+    "prettier-plugin-tailwindcss": "^0.2.7"
   }
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,24 +6,24 @@ export default function Home() {
     <main className="p-2">
       <h1>Next.js + Tailwind CSS</h1>
 
-      <h2 className="text-2xl font-bold my-5">Components</h2>
+      <h2 className="my-5 text-2xl font-bold">Components</h2>
 
       <div id="wrapper" className="flex flex-wrap">
         <div className="basis-1/3">
-          <h3 className="font-bold text-xl mb-3">Buttons</h3>
+          <h3 className="mb-3 text-xl font-bold">Buttons</h3>
           <Button>component example</Button>
         </div>
 
         <div className="basis-1/3">
-          <h3 className="font-bold text-xl mb-3">Badges</h3>
-          <div className="flex gap-3 flex-row">
+          <h3 className="mb-3 text-xl font-bold">Badges</h3>
+          <div className="flex flex-row gap-3">
             <Badge />
             <Badge variant="ongoing" />
             <Badge variant="resolved" />
           </div>
         </div>
         <div className="basis-1/3">
-          <h3 className="font-bold text-xl mb-3">Lorem</h3>
+          <h3 className="mb-3 text-xl font-bold">Lorem</h3>
           <p>
             Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ex dolor
             consequatur recusandae, possimus distinctio voluptas quos reiciendis
@@ -32,7 +32,7 @@ export default function Home() {
           </p>
         </div>
         <div className="basis-1/3">
-          <h3 className="font-bold text-xl mb-3">Lorem</h3>
+          <h3 className="mb-3 text-xl font-bold">Lorem</h3>
           <p>
             Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ex dolor
             consequatur recusandae, possimus distinctio voluptas quos reiciendis
@@ -41,7 +41,7 @@ export default function Home() {
           </p>
         </div>
         <div className="basis-1/3">
-          <h3 className="font-bold text-xl mb-3">Lorem</h3>
+          <h3 className="mb-3 text-xl font-bold">Lorem</h3>
           <p>
             Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ex dolor
             consequatur recusandae, possimus distinctio voluptas quos reiciendis

--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -15,7 +15,7 @@ const badgeVariant = cva('w-5 h-5 rounded-full', {
 
 export default function Badge({ variant }) {
   return (
-    <div class="inline-flex gap-2 items-center justify-center md:pl-1 md:pr-4 h-8 text-sm rounded-full md:border-2 border-hlight text-center text-primary-700 md:cursor-pointer md:transition md:duration-200 md:hover:scale-105 md:hover:shadow-md">
+    <div class="text-primary-700 inline-flex h-8 items-center justify-center gap-2 rounded-full border-hlight text-center text-sm md:cursor-pointer md:border-2 md:pl-1 md:pr-4 md:transition md:duration-200 md:hover:scale-105 md:hover:shadow-md">
       <span className={badgeVariant({ variant })}></span>
       <span className="hidden md:block">{variant || 'open'}</span>
     </div>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,5 +1,5 @@
 export default function Button({ children }) {
   return (
-    <button className="py-3 px-8 bg-hyellow text-hdark">{children}</button>
+    <button className="bg-hyellow px-8 py-3 text-hdark">{children}</button>
   );
 }


### PR DESCRIPTION
Added prettier-tailwind.

> A Prettier plugin for Tailwind CSS v3.0+ that automatically sorts classes based on our recommended class order.

