### PR TITLE
fix: set all margin-top for inputs to mt-4 so that they all match

### DIFF
--- a/src/components/ReportForm/SelectDevice.jsx
+++ b/src/components/ReportForm/SelectDevice.jsx
@@ -52,7 +52,7 @@ const SelectDevice = forwardRef(({ register, setValue }, ref) => {
       <label className="text-xl font-bold">Faulty device</label>
       <RadioGroup.Root
         name="device"
-        className="mt-5 flex flex-col space-y-4 md:pl-5"
+        className="mt-4 flex flex-col space-y-4 md:pl-5"
         onChange={(event) => handleDeviceChange(event)}
         defaultValue="iMac"
       >


### PR DESCRIPTION
Hello,
all the inputs now have margin top-4, only one of them was set to mt-5 so i fixed that one in select device.