### PR TITLE
fix: removed state logic from issue table, issues change is now handl…

### DIFF
--- a/src/app/api/issues/[id]/route.js
+++ b/src/app/api/issues/[id]/route.js
@@ -23,7 +23,7 @@ export async function PATCH(request, { params }) {
   if (user && user.admin) {
     try {
       const issue = await request.json();
-      const issueUpdate = await prisma.Issue.update({
+      await prisma.Issue.update({
         where: {
           id: Number(params.id),
         },
@@ -32,9 +32,7 @@ export async function PATCH(request, { params }) {
           closed: issue.status === 'resolved' ? new Date() : null,
         },
       });
-      return new Response(JSON.stringify(issueUpdate), {
-        status: 200,
-      });
+      return new Response({}, { status: 200 });
     } catch (error) {
       console.log(`#########\n ${error.message} \n#########`);
       return new Response({}, { status: 500 });

--- a/src/app/api/issues/route.js
+++ b/src/app/api/issues/route.js
@@ -13,6 +13,9 @@ export async function GET() {
       let issues = [];
       if (user.admin === true) {
         issues = await prisma.Issue.findMany({
+          orderBy: {
+            id: 'desc',
+          },
           include: {
             user: {
               select: {
@@ -25,6 +28,9 @@ export async function GET() {
         issues = await prisma.Issue.findMany({
           where: {
             userId: user.user_id,
+          },
+          orderBy: {
+            id: 'desc',
           },
           include: {
             user: {
@@ -65,7 +71,7 @@ export async function POST(request) {
       if (ymlData.hosts.includes(issue.host) === false) {
         return new Response({ status: 400 });
       }
-      const issueCreation = await prisma.Issue.create({
+      await prisma.Issue.create({
         data: {
           host: issue.host,
           device: issue.device,

--- a/src/components/IssuesTable/Issue.jsx
+++ b/src/components/IssuesTable/Issue.jsx
@@ -4,16 +4,12 @@ import SelectStatus from './SelectStatus';
 import { ChevronDownIcon } from 'lucide-react';
 import moment from 'moment';
 import { useState } from 'react';
-const Issue = ({ props }) => {
-  const { user, checkedResolved } = props;
-  const [issue, setIssue] = useState(props.issue);
-  const [selectedStatus, setSelectedStatus] = useState(issue.status);
-  const userIssue = props.issue.user.login;
-
+const Issue = ({ issue, user, checkedResolved, setTriggerSorting }) => {
+  const [open, setOpen] = useState(false);
   const handleStatus = async (event) => {
     const possibleStatus = ['open', 'ongoing', 'resolved'];
     if (possibleStatus.includes(event)) {
-      const data = await fetch(`/api/issues/${issue.id}`, {
+      await fetch(`/api/issues/${issue.id}`, {
         method: 'PATCH',
         body: JSON.stringify({
           status: event,
@@ -22,13 +18,12 @@ const Issue = ({ props }) => {
           'Content-type': 'application/json; charset=UTF-8',
         },
       });
-      const issueUpdate = await data.json();
-      setIssue(issueUpdate);
-      setSelectedStatus(event);
+      setTriggerSorting((prev) => !prev);
+      setOpen(!open);
     }
   };
 
-  if (checkedResolved === false && selectedStatus === 'resolved') return null;
+  if (checkedResolved === false && issue.status === 'resolved') return null;
   return (
     <Accordion.Item value={issue.id} className=" text-hdark">
       <Accordion.Header className="group relative flex w-full items-center justify-between border-b px-5 py-4">
@@ -41,8 +36,10 @@ const Issue = ({ props }) => {
         <div className="absolute right-16 inline-flex items-center gap-6 md:right-9">
           <SelectStatus
             user={user}
-            selectedStatus={selectedStatus}
+            status={issue.status}
             handleStatus={handleStatus}
+            open={open}
+            setOpen={setOpen}
           />
         </div>
       </Accordion.Header>
@@ -57,10 +54,10 @@ const Issue = ({ props }) => {
           <p className="mt-5 text-sm">
             created by{' '}
             <Link
-              href={`https://profile.intra.42.fr/users/${userIssue}`}
+              href={`https://profile.intra.42.fr/users/${issue.user.login}`}
               className="underline"
             >
-              {userIssue}
+              {issue.user.login}
             </Link>{' '}
             {moment(issue.created).fromNow()}
             {issue.closed && ` and closed ${moment(issue.closed).fromNow()}`}

--- a/src/components/IssuesTable/IssuesTable.jsx
+++ b/src/components/IssuesTable/IssuesTable.jsx
@@ -5,18 +5,9 @@ import { CheckIcon } from '@radix-ui/react-icons';
 import { useState, useEffect } from 'react';
 import Issue from './Issue.jsx';
 
-const RenderIssues = ({ props }) => {
-  const { issues, user, checkedResolved } = props;
-  if (issues.length > 0)
-    return props.issues.map((issue) => {
-      return <Issue props={{ issue, user, checkedResolved }} key={issue.id} />;
-    });
-};
-
-const IssuesTable = ({ user }) => {
-  const [checkedResolved, setCheckedResolved] = useState(false);
+const RenderIssues = ({ user, checkedResolved }) => {
   const [issues, setIssues] = useState([]);
-
+  const [triggerSorting, setTriggerSorting] = useState(false);
   useEffect(() => {
     const fetchInfo = async () => {
       const data = await fetch('/api/issues');
@@ -24,30 +15,45 @@ const IssuesTable = ({ user }) => {
       setIssues(jsonData);
     };
     fetchInfo();
-  }, []);
+  }, [triggerSorting]);
 
-  if (issues.length > 0) {
-    return (
-      <div className="mt-11 w-full md:container">
-        <div className="mb-5 flex w-full flex-row justify-end gap-5">
-          <div className="flex items-center gap-2">
-            <Checkbox.Root
-              className="flex h-4 w-4 appearance-none items-center justify-center border border-slate-400 bg-white outline-none"
-              onCheckedChange={(event) => setCheckedResolved(event)}
-            >
-              <Checkbox.Indicator>
-                <CheckIcon className="h-5 w-5" />
-              </Checkbox.Indicator>
-            </Checkbox.Root>
-            <label className="leading-none text-slate-600">Resolved</label>
-          </div>
+  if (issues.length > 0)
+    return issues.map((issue) => {
+      return (
+        <Issue
+          issue={issue}
+          user={user}
+          checkedResolved={checkedResolved}
+          setTriggerSorting={setTriggerSorting}
+          key={issue.id}
+        />
+      );
+    });
+};
+
+const IssuesTable = ({ user }) => {
+  const [checkedResolved, setCheckedResolved] = useState(false);
+
+  return (
+    <div className="mt-11 w-full md:container">
+      <div className="mb-5 flex w-full flex-row justify-end gap-5">
+        <div className="flex items-center gap-2">
+          <Checkbox.Root
+            className="flex h-4 w-4 appearance-none items-center justify-center border border-slate-400 bg-white outline-none"
+            onCheckedChange={(event) => setCheckedResolved(event)}
+          >
+            <Checkbox.Indicator>
+              <CheckIcon className="h-5 w-5" />
+            </Checkbox.Indicator>
+          </Checkbox.Root>
+          <label className="leading-none text-slate-600">Resolved</label>
         </div>
-        <Accordion.Root type="single" collapsible className="w-full border">
-          <RenderIssues props={{ issues, user, checkedResolved }} />
-        </Accordion.Root>
       </div>
-    );
-  }
+      <Accordion.Root type="single" collapsible className="w-full border">
+        <RenderIssues user={user} checkedResolved={checkedResolved} />
+      </Accordion.Root>
+    </div>
+  );
 };
 
 export default IssuesTable;

--- a/src/components/IssuesTable/SelectStatus.jsx
+++ b/src/components/IssuesTable/SelectStatus.jsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useState } from 'react';
-
 import {
   Popover,
   PopoverContent,
@@ -9,15 +7,13 @@ import {
 } from '@components/ui/popover';
 import Badge from '../Badge';
 
-const SelectStatus = ({ user, selectedStatus, handleStatus }) => {
-  const [open, setOpen] = useState(false);
-
+const SelectStatus = ({ user, status, handleStatus, open, setOpen }) => {
   return (
     <div className="flex items-center space-x-4">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <div>
-            <Badge variant={selectedStatus} />
+            <Badge variant={status} />
           </div>
         </PopoverTrigger>
         {user.admin && (


### PR DESCRIPTION
Hello 🍉 
In this PR I changed the handling of issue states from the useState to a simple http request that will re-fetch the issues already sorted from the database after Patching the modified one.
Also while removing and moving different states between component I moved the one that handles the open or closed state of the select status, this way after changing an issue status the popover will close.

Please review before I merge :)
