### PR TITLE
fix: validation colour for short description

### DIFF
--- a/src/components/ReportForm/Description.jsx
+++ b/src/components/ReportForm/Description.jsx
@@ -30,7 +30,10 @@ const Description = ({ watch, register, errors }) => {
           <div
             className={`absolute -bottom-6 right-0 mb-2 mr-2 text-xs font-light
             ${
-              watch('description').length > 400 ? 'text-hred' : 'text-gray-400'
+              watch('description').length > 400 ||
+              watch('description').length < 25
+                ? 'text-hred'
+                : 'text-gray-400'
             }`}
           >
             {watch('description').length}/400

--- a/src/components/ReportForm/Description.jsx
+++ b/src/components/ReportForm/Description.jsx
@@ -22,7 +22,7 @@ const Description = ({ watch, register, errors }) => {
             placeholder="Type your description..."
             {...register('description', {
               required: 'This is required',
-              minLength: { value: 10, message: 'Minimum 10 characters' },
+              minLength: { value: 25, message: 'Minimum 25 characters' },
               maxLength: { value: 400, message: 'Maximum 400 characters' },
             })}
             className="w-full border border-b-4 px-4 py-6 outline-none"


### PR DESCRIPTION
Hi,
Just added logic to make a short description (of less than 25 characters) to highlight the character count for the validation to red.
The changes work as desired, but I am not sure if the syntax is 100% correct or if there is a different best practice.
If you could please review that and merge if all is good.
Thanks! :)