### PR TITLE
fix: api route shouldn't return an object on error

### DIFF
--- a/src/app/api/devices/route.js
+++ b/src/app/api/devices/route.js
@@ -7,6 +7,6 @@ export async function GET() {
     return Response.json({ devices: ymlData.devices });
   } catch (error) {
     console.log(error);
-    return new Response({}, { status: 500 });
+    return new Response('', { status: 500 });
   }
 }

--- a/src/app/api/hosts/route.js
+++ b/src/app/api/hosts/route.js
@@ -7,6 +7,6 @@ export async function GET() {
     return Response.json({ hosts: ymlData.hosts });
   } catch (error) {
     console.log(error);
-    return new Response({}, { status: 500 });
+    return new Response('', { status: 500 });
   }
 }

--- a/src/app/api/issues/[id]/route.js
+++ b/src/app/api/issues/[id]/route.js
@@ -14,7 +14,7 @@ export async function GET(request, { params }) {
     });
   } catch (error) {
     console.log(`#########\n ${error.message} \n#########`);
-    return new Response({}, { status: 500 });
+    return new Response('', { status: 500 });
   }
 }
 
@@ -32,13 +32,13 @@ export async function PATCH(request, { params }) {
           closed: issue.status === 'resolved' ? new Date() : null,
         },
       });
-      return new Response({}, { status: 200 });
+      return new Response('', { status: 200 });
     } catch (error) {
       console.log(`#########\n ${error.message} \n#########`);
-      return new Response({}, { status: 500 });
+      return new Response('', { status: 500 });
     }
   } else {
     console.log(`#########\n UNAUTORISED \n#########`);
-    return new Response({}, { status: 401 });
+    return new Response('', { status: 401 });
   }
 }

--- a/src/app/api/issues/route.js
+++ b/src/app/api/issues/route.js
@@ -8,7 +8,7 @@ export async function GET() {
   const user = await getCurrentUser();
   if (!user) {
     console.log(`#########\n UNAUTORISED \n#########`);
-    return new Response({}, { status: 401 });
+    return new Response('', { status: 401 });
   } else {
     try {
       let issues = [];
@@ -55,7 +55,7 @@ export async function GET() {
       });
     } catch (error) {
       console.log(`#########\n ${error.message} \n#########`);
-      return new Response({}, { status: 500 });
+      return new Response('', { status: 500 });
     }
   }
 }
@@ -64,13 +64,13 @@ export async function POST(request) {
   const user = await getCurrentUser();
   if (!user) {
     console.log(`#########\n UNAUTORISED \n#########`);
-    return new Response({}, { status: 401 });
+    return new Response('', { status: 401 });
   } else {
     try {
       const issue = await request.json();
 
       if (ymlData.hosts.includes(issue.host) === false) {
-        return new Response({ status: 400 });
+        return new Response('', { status: 400 });
       }
       await prisma.Issue.create({
         data: {
@@ -84,10 +84,10 @@ export async function POST(request) {
           },
         },
       });
-      return new Response({}, { status: 201 });
+      return new Response('', { status: 201 });
     } catch (error) {
       console.log(`#########\n ${error.message} \n#########`);
-      return new Response({}, { status: 500 });
+      return new Response('', { status: 500 });
     }
   }
 }

--- a/src/app/api/users/[id]/route.js
+++ b/src/app/api/users/[id]/route.js
@@ -12,6 +12,6 @@ export async function GET(request, { params }) {
     });
   } catch (error) {
     console.log(`#########\n ${error.message} \n#########`);
-    return new Response({}, { status: 500 });
+    return new Response('', { status: 500 });
   }
 }

--- a/src/app/api/users/route.js
+++ b/src/app/api/users/route.js
@@ -8,7 +8,7 @@ export async function GET() {
     });
   } catch (error) {
     console.log(`#########\n ${error.message} \n#########`);
-    return new Response({}, { status: 500 });
+    return new Response('', { status: 500 });
   }
 }
 
@@ -22,7 +22,7 @@ export async function POST(request) {
       },
     });
     if (userExists) {
-      return new Response({}, { status: 409 });
+      return new Response('', { status: 409 });
     } else {
       const userCreation = await prisma.User.create({
         data: {
@@ -37,7 +37,7 @@ export async function POST(request) {
     }
   } catch (error) {
     console.log(`#########\n ${error.message} \n#########`);
-    return new Response({}, { status: 500 });
+    return new Response('', { status: 500 });
   }
 }
 // curl -d '{"id": 1, "login": "testuser", "admin": false}' localhost:3000/api/users


### PR DESCRIPTION
I realised that the approach of returning `{}` when the API calls are unauthorized or on error was not correct, it was returning a Response `[object Object]`

This PR fix this issue :)