### PR TITLE
feat: add ability to user to set as open or resolved their reports

### DIFF
--- a/src/app/api/issues/[id]/route.js
+++ b/src/app/api/issues/[id]/route.js
@@ -34,7 +34,7 @@ const issueUpdate = async (prisma, params, issue) => {
 export async function PATCH(request, { params }) {
   const user = await getCurrentUser(request);
   const issue = await request.json();
-  const userCan = ['open', 'resolved'];
+  const userCan = ['resolved'];
 
   if (userCan.includes(issue.status)) {
     if (user && user.id === issue.user_id) {

--- a/src/components/IssuesTable/Issue.jsx
+++ b/src/components/IssuesTable/Issue.jsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import * as Accordion from '@radix-ui/react-accordion';
-import SelectStatus from './SelectStatus';
+import { useState } from 'react';
 import { ChevronDownIcon } from 'lucide-react';
 import moment from 'moment';
-import { useState } from 'react';
+import * as Accordion from '@radix-ui/react-accordion';
+import SelectStatus from './SelectStatus';
 
 const Issue = ({ issue, user, checkedResolved, setTriggerSorting }) => {
   const [open, setOpen] = useState(false);

--- a/src/components/IssuesTable/SelectStatus.jsx
+++ b/src/components/IssuesTable/SelectStatus.jsx
@@ -10,7 +10,7 @@ import Badge from '../Badge';
 
 const SelectStatus = ({ user, status, handleStatus, open, setOpen }) => {
   const adminStatus = ['open', 'ongoing', 'resolved'];
-  const userStatus = ['open', 'resolved'];
+  const userStatus = ['resolved'];
 
   return (
     <div className="flex items-center space-x-4">

--- a/src/components/IssuesTable/SelectStatus.jsx
+++ b/src/components/IssuesTable/SelectStatus.jsx
@@ -5,9 +5,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@components/ui/popover';
+import Status from './Status';
 import Badge from '../Badge';
 
 const SelectStatus = ({ user, status, handleStatus, open, setOpen }) => {
+  const adminStatus = ['open', 'ongoing', 'resolved'];
+  const userStatus = ['open', 'resolved'];
+
   return (
     <div className="flex items-center space-x-4">
       <Popover open={open} onOpenChange={setOpen}>
@@ -16,41 +20,31 @@ const SelectStatus = ({ user, status, handleStatus, open, setOpen }) => {
             <Badge variant={status} />
           </div>
         </PopoverTrigger>
-        {user.admin && (
-          <PopoverContent
-            className=" flex w-[110px] flex-col gap-2 divide-y text-sm"
-            side="bottom"
-            align="start"
-            onClick={(event) =>
-              handleStatus(event.target.getAttribute('value'))
-            }
-          >
+        <PopoverContent
+          className=" flex w-[110px] flex-col gap-2 divide-y text-sm"
+          side="bottom"
+          align="start"
+          onClick={(event) => handleStatus(event.target.getAttribute('value'))}
+        >
+          {user.admin ? (
             <div className="flex flex-col gap-2">
-              <p
-                value="open"
-                className="cursor-pointer hover:font-semibold hover:text-slate-500"
-              >
-                Open
-              </p>
-              <p
-                value="ongoing"
-                className="cursor-pointer hover:font-semibold hover:text-horange"
-              >
-                Ongoing
-              </p>
-              <p
-                value="resolved"
-                className="cursor-pointer hover:font-semibold hover:text-hgreen"
-              >
-                Resolved
-              </p>
+              {adminStatus.map((status, id) => (
+                <Status key={id} status={status} />
+              ))}
             </div>
-
+          ) : (
+            <div className="flex flex-col gap-2">
+              {userStatus.map((status, id) => (
+                <Status key={id} status={status} />
+              ))}
+            </div>
+          )}
+          {user.admin && (
             <div className="cursor-pointer pt-2 text-red-600 hover:font-semibold">
               <p value="delete">Delete</p>
             </div>
-          </PopoverContent>
-        )}
+          )}
+        </PopoverContent>
       </Popover>
     </div>
   );

--- a/src/components/IssuesTable/Status.jsx
+++ b/src/components/IssuesTable/Status.jsx
@@ -1,0 +1,24 @@
+import { tv } from 'tailwind-variants';
+
+const statusVariant = tv({
+  base: 'cursor-pointer hover:font-semibold',
+  variants: {
+    status: {
+      open: 'hover:text-slate-500',
+      ongoing: 'hover:text-horange',
+      resolved: 'hover:text-hgreen',
+    },
+  },
+});
+
+const Status = ({ status }) => {
+  const capitalized = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+
+  return (
+    <p value={status} className={statusVariant({ status })}>
+      {capitalized(status)}
+    </p>
+  );
+};
+
+export default Status;


### PR DESCRIPTION
Hello 👋🏻 

Moving forward, allowing users to interact with their reports:

- Added ability for a user to set as `open` or `resolve` their reports

In addition:
- Created a Status component to make SelectStatus less bulky
- review the way I pass argument to `slack_notification`

To consider, `PATCH` on `/issues/[id]` is now pretty big, it might be worth improving that in the future. 

**-- To be reviewed and merged**